### PR TITLE
Add git as a "bin" dependency

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,8 @@
   "build-depends": [
   ],
   "depends": [
-    "path-utils:ver<0.0.13>:auth<zef:lizmat>"
+    "path-utils:ver<0.0.13>:auth<zef:lizmat>",
+    "git:from<bin>"
   ],
   "description": "List known files of a git repository",
   "license": "Artistic-2.0",


### PR DESCRIPTION
Since the code of this module relies on calling `git` as an executable, it's not usable without this command being available. It makes sense to make this dependency transparent.